### PR TITLE
Collect traces by aux_head and aux_tail

### DIFF
--- a/hase/perf/__init__.py
+++ b/hase/perf/__init__.py
@@ -81,8 +81,7 @@ class Perf:
                 continue
             trace_path = os.path.join(directory, "cpu-%d.trace" % cpu.idx)
             with open(trace_path, "wb") as trace_file:
-                for trace in cpu.traces():
-                    trace_file.write(trace)
+                trace_file.write(cpu.traces())
 
             itrace = cpu.itrace_start_event()
             cpu_trace = CpuTrace(


### PR DESCRIPTION
According to https://github.com/torvalds/linux/commit/1627314fb54a33ebd23bd08f2e215eaed0f44712, in Linux after `4.20`, `PERF_RECORD_AUX` won't supply enough information for us, we should use `aux_head` and `aux_tail` to collect traces.
As I have said in https://github.com/hase-project/hase/pull/91#issuecomment-471319641, we assume the size of collected records will not greater than the buffer holds them now, so the implement here is really simple. We can add more checks in the future.
