### PR TITLE
Correct add-symbol-file addr

### DIFF
--- a/hase/symbex/tracer.py
+++ b/hase/symbex/tracer.py
@@ -10,6 +10,7 @@ import angr
 import archinfo
 from angr import Block, Project, SimState
 from angr.engines.successors import SimSuccessors
+from cle.backends.elf.metaelf import MetaELF
 from capstone import x86_const
 
 from ..errors import HaseError
@@ -105,8 +106,13 @@ class Tracer:
         start = elf.symbols.get("_start")
         main = elf.symbols.get("main")
 
+        lib_text_addrs = {}  # type: Dict[str, int]
+        lib_opts = self.loader.load_options()["lib_opts"]
+        for lib in lib_opts:
+            lib_text_addrs[lib] = lib_opts[lib]['base_addr'] + MetaELF.get_text_offset(lib)
+
         self.cdanalyzer = CoredumpAnalyzer(
-            elf, self.coredump, self.loader.load_options()["lib_opts"]
+            elf, self.coredump, lib_text_addrs
         )
 
         for (idx, event) in enumerate(self.trace):


### PR DESCRIPTION
The `ADDR` argument used by `add-symbol-file` should be the starting address of the file's text section.

In fact, I hope to use `set solib-search-path` or `set sysroot` rather than `add-symbol-file`, they are more elegant to add symbols. However, the library names depended by ELF and found in memory maps are different (`libc.so.6` vs `libc-2.27.so`), I can't find convenient way to do it.